### PR TITLE
[WEB-34861] Fix IPv6 Validation

### DIFF
--- a/src/saml2_tophat/validate.py
+++ b/src/saml2_tophat/validate.py
@@ -4,6 +4,9 @@ import re
 import struct
 import base64
 import time
+from ipaddress import AddressValueError
+from ipaddress import IPv4Address
+from ipaddress import IPv6Address
 
 from saml2_tophat import time_util
 
@@ -112,55 +115,30 @@ def validate_before(not_before, slack):
 
 
 def valid_address(address):
+    """Validate IPv4/IPv6 addresses."""
     if not (valid_ipv4(address) or valid_ipv6(address)):
         raise NotValid("address")
     return True
 
 
 def valid_ipv4(address):
-    parts = address.split(".")
-    if len(parts) != 4:
+    """Validate IPv4 addresses."""
+    try:
+        IPv4Address(address)
+    except AddressValueError:
         return False
-    for item in parts:
-        try:
-            if not 0 <= int(item) <= 255:
-                raise NotValid("ipv4")
-        except ValueError:
-            return False
     return True
-
-#
-IPV6_PATTERN = re.compile(r"""
-    ^
-    \s*                         # Leading whitespace
-    (?!.*::.*::)                # Only a single wildcard allowed
-    (?:(?!:)|:(?=:))            # Colon iff it would be part of a wildcard
-    (?:                         # Repeat 6 times:
-        [0-9a-f]{0,4}           #   A group of at most four hexadecimal digits
-        (?:(?<=::)|(?<!::):)    #   Colon unless preceeded by wildcard
-    ){6}                        #
-    (?:                         # Either
-        [0-9a-f]{0,4}           #   Another group
-        (?:(?<=::)|(?<!::):)    #   Colon unless preceeded by wildcard
-        [0-9a-f]{0,4}           #   Last group
-        (?: (?<=::)             #   Colon iff preceeded by exacly one colon
-         |  (?<!:)              #
-         |  (?<=:) (?<!::) :    #
-         )                      # OR
-     |                          #   A v4 address with NO leading zeros
-        (?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)
-        (?: \.
-            (?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)
-        ){3}
-    )
-    \s*                         # Trailing whitespace
-    $
-""", re.VERBOSE | re.IGNORECASE | re.DOTALL)
 
 
 def valid_ipv6(address):
     """Validates IPv6 addresses. """
-    return IPV6_PATTERN.match(address) is not None
+    is_enclosed_in_brackets = address.startwith("[") and address.endswith("]")
+    address_raw = address[1:-1] if is_enclosed_in_brackets else address
+    try:
+        IPv6Address(address_raw)
+    except AddressValueError:
+        return False
+    return True
 
 
 def valid_boolean(val):

--- a/src/saml2_tophat/validate.py
+++ b/src/saml2_tophat/validate.py
@@ -132,7 +132,7 @@ def valid_ipv4(address):
 
 def valid_ipv6(address):
     """Validates IPv6 addresses. """
-    is_enclosed_in_brackets = address.startwith("[") and address.endswith("]")
+    is_enclosed_in_brackets = address.startswith("[") and address.endswith("]")
     address_raw = address[1:-1] if is_enclosed_in_brackets else address
     try:
         IPv6Address(address_raw)

--- a/tests/test_13_validate.py
+++ b/tests/test_13_validate.py
@@ -13,6 +13,7 @@ from saml2_tophat.validate import valid_instance
 from saml2_tophat.validate import valid_any_uri
 from saml2_tophat.validate import NotValid
 from saml2_tophat.validate import valid_anytype
+from saml2_tophat.validate import valid_address
 
 from py.test import raises
 
@@ -112,4 +113,29 @@ def test_valid_anytype():
     assert valid_anytype("-1234")
     assert valid_anytype("P1Y2M3DT10H30M")
     assert valid_anytype("urn:oasis:names:tc:SAML:2.0:attrname-format:uri")
+
+
+def test_valid_address():
+    assert valid_address("130.239.16.3")
+    assert valid_address("2001:8003:5555:9999:555a:5555:c77:d5c5")
+    assert valid_address("2001:8003:5555::555a:5555:c77:d5c5")
+
+    # See https://tools.ietf.org/html/rfc4038#section-5.1 regarding
+    # the inclusion of brackets in the ipv6 address below.
+    assert valid_address("[2001:8003:5555:9999:555a:5555:c77:d5c5]")
+
+    with raises(NotValid):
+        assert valid_address("127.0.0.256")
+    with raises(NotValid):
+        assert valid_address("127.0.0.")
+    with raises(NotValid):
+        assert valid_address("127.0.0")
+    with raises(NotValid):
+        assert valid_address("2001::5555:9999::5555:c77:d5c5]")
+    with raises(NotValid):
+        assert valid_address("2001:8003:5555:9999:555a:5555:c77:d5c5]")
+    with raises(NotValid):
+        assert valid_address("[2001:8003:5555:9999:555a:5555:c77:d5c5")
+    with raises(NotValid):
+        assert valid_address("[[2001:8003:5555:9999:555a:5555:c77:d5c5]")
 


### PR DESCRIPTION
This is to fix a bug of not being able to validate the IPv6 address with square brackets around it. Please refer to the original [issue](https://github.com/IdentityPython/pysaml2/issues/627) and [fix](https://github.com/IdentityPython/pysaml2/pull/653).

This fix is using Python's Libraries to validate the IPv4 and IPv6 addresses instead of manually matching their patterns.

Ticket:
https://tophat.atlassian.net/browse/WEB-34861

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



