### PR TITLE
Add QA/deployment steps for Top Hat fork

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,50 @@ work in a WSGI environment there are extensions that allow you to use it with
 other frameworks.
 
 
+Top Hat fork
+============
+
+This is a Top-Hat-specific fork of PySAML2. It's published manually to JFrog and consumed by THM.
+
+How to package a new version
+----------------------------
+
+* On your branch, update the VERSION file - our convention seems to be ``<PySAML2 base version>-N`` where ``N`` is the number of TopHat's revision on top of the upstream version. E.g. ``4.6.5-2`` is the second revision since merging the upstream ``4.6.5`` version.
+* create venv?
+* ``python setup.py bdist_wheel --universal``
+* Find the wheel file in ``dist/`` folder
+
+How to QA your changes
+----------------------
+
+* ``docker cp`` the wheel file generated above into your development THM container
+* ``th shell thm`` to enter the container
+* ``pip list | grep pysaml`` - note the currently installed version
+* ``pip uninstall pysaml2-tophat``
+* ``re`` - this step may be excessive, but confirm that THM either won't start or SSO is broken. This will guarantee that when you install the new version, it's the new version that's running.
+* ``pip install <path to wheel file>``
+* ``pip list`` - confirm the new version is installed
+* ``re`` and QA
+
+How to deploy a new version
+---------------------------
+
+* Merge your branch to master
+* Create a new Github release using the version convention described above
+* Attach the wheel file to the release assets for posterity
+* Get a member of ``@platform_help_me`` to upload the wheel file to JFrog for you
+* Start a new THM branch
+* Update the version of ``pysaml2-tophat`` in ``requirements_common.txt``. It won't be exactly the tag you used. E.g. if you put ``4.6.5-2`` in the VERSION file, you should put ``4.6.5.post2`` here. It should match part of the wheel file name.
+* ``th shell thm`` to enter your dev container
+* ``pip list | grep pysaml`` - note the currently installed version
+* ``pip uninstall pysaml2-tophat``
+* ``re`` - this step may be excessive, but confirm that THM either won't start or SSO is broken. This will guarantee that when you install the new version, it's the new version that's running.
+* ``pip install -r requirements.txt``
+* ``pip list`` - confirm the new version is installed
+* ``re`` and smoke test
+* Merge THM branch
+
+
 Testing
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,10 @@ How to package a new version
 ----------------------------
 
 * On your branch, update the VERSION file - our convention seems to be ``<PySAML2 base version>-N`` where ``N`` is the number of TopHat's revision on top of the upstream version. E.g. ``4.6.5-2`` is the second revision since merging the upstream ``4.6.5`` version.
-* create venv?
-* ``python setup.py bdist_wheel --universal``
+* Create a virtualenv to build the package in
+    - ``python3 -m venv <some name>``
+    - ``. <some name>/bin/activate``
+* In the venv, ``python setup.py bdist_wheel --universal``
 * Find the wheel file in ``dist/`` folder
 
 How to QA your changes


### PR DESCRIPTION
This adds QA and deployment steps for the process we learned in Jan 2021 while working on #4.