### PR TITLE
Fix codec function selection

### DIFF
--- a/src/saml2_tophat/saml.py
+++ b/src/saml2_tophat/saml.py
@@ -87,8 +87,12 @@ XSD = "xs"
 NS_SOAP_ENC = "http://schemas.xmlsoap.org/soap/encoding/"
 
 
-_b64_decode_fn = getattr(base64, 'decodebytes', base64.decodestring)
-_b64_encode_fn = getattr(base64, 'encodebytes', base64.encodestring)
+if hasattr(base64, "encodebytes"):
+    _b64_decode_fn = base64.decodebytes
+    _b64_encode_fn = base64.encodebytes
+else:
+    _b64_decode_fn = base64.decodestring
+    _b64_encode_fn = base64.encodestring
 
 
 class AttributeValueBase(SamlBase):


### PR DESCRIPTION
### Description

Arguments to a function are evaluated before being passed. The statement as written fails if `base64.encodestring` doesn't exist. This fixes the check now that the function has actually been removed.